### PR TITLE
feat: improve bible loading and verse rendering

### DIFF
--- a/assets/bible/joao/1.json
+++ b/assets/bible/joao/1.json
@@ -1,13 +1,37 @@
 {
-    "book_slug": "joao",
-    "chapter": 1,
-    "rtl_original": false,
-    "verses": [
-        {
-            "n": 1,
-            "original": "Ἐν ἀρχῇ ἦν ὁ Λόγος, καὶ ὁ Λόγος ἦν πρὸς τὸν Θεόν, καὶ Θεὸς ἦν ὁ Λόγος.",
-            "translit": "En archē ēn ho Lógos, kai ho Lógos ēn pros ton Theón, kai Theós ēn ho Lógos.",
-            "pt": "No princípio era o Logos, e o Logos estava com Deus, e Deus era o Logos."
-        }
-    ]
+  "book_slug": "joao",
+  "chapter": 1,
+  "rtl_original": false,
+  "verses": [
+    {
+      "n": 1,
+      "original": "Ἐν ἀρχῇ ἦν ὁ Λόγος",
+      "translit": "En archē ēn ho Lógos",
+      "pt": "No princípio era o Logos"
+    },
+    {
+      "n": 2,
+      "original": "οὗτος ἦν ἐν ἀρχῇ πρὸς τὸν Θεόν",
+      "translit": "houtos ēn en archē pros ton Theón",
+      "pt": "Ele estava no princípio com Deus"
+    },
+    {
+      "n": 3,
+      "original": "πάντα δι' αὐτοῦ ἐγένετο",
+      "translit": "panta di' autou egeneto",
+      "pt": "Todas as coisas foram feitas por meio dele"
+    },
+    {
+      "n": 4,
+      "original": "ἐν αὐτῷ ζωὴ ἦν",
+      "translit": "en autō zōē ēn",
+      "pt": "Nele estava a vida"
+    },
+    {
+      "n": 5,
+      "original": "καὶ ἡ σκοτία αὐτὸ οὐ κατέλαβεν",
+      "translit": "kai hē skotia auto ou katelaben",
+      "pt": "e as trevas não a venceram"
+    }
+  ]
 }

--- a/lib/presentation/bible_text_reader/bible_text_reader.dart
+++ b/lib/presentation/bible_text_reader/bible_text_reader.dart
@@ -51,7 +51,7 @@ const Map<String, dynamic> MOCK_JOAO_1 = {
   ]
 };
 
-const FORCE_MOCK = true;
+const FORCE_MOCK = false;
 const DEBUG_HUD = true;
 
 class BibleTextReader extends StatefulWidget {
@@ -69,7 +69,13 @@ class _BibleTextReaderState extends State<BibleTextReader> {
   @override
   void initState() {
     super.initState();
-    _loaderResult = useChapterLoader(_bookSlug, _chapter);
+    _loaderResult = useChapterLoader(
+      _bookSlug,
+      _chapter,
+      onStateChange: () {
+        setState(() {});
+      },
+    );
   }
 
   @override
@@ -85,7 +91,13 @@ class _BibleTextReaderState extends State<BibleTextReader> {
         setState(() {
           _bookSlug = newBookSlug;
           _chapter = newChapter;
-          _loaderResult = useChapterLoader(_bookSlug, _chapter);
+          _loaderResult = useChapterLoader(
+            _bookSlug,
+            _chapter,
+            onStateChange: () {
+              setState(() {});
+            },
+          );
         });
       }
     }
@@ -106,7 +118,13 @@ class _BibleTextReaderState extends State<BibleTextReader> {
 
   void _retry() {
     setState(() {
-      _loaderResult = useChapterLoader(_bookSlug, _chapter);
+      _loaderResult = useChapterLoader(
+        _bookSlug,
+        _chapter,
+        onStateChange: () {
+          setState(() {});
+        },
+      );
     });
   }
 
@@ -159,7 +177,7 @@ class _BibleTextReaderState extends State<BibleTextReader> {
       return _buildLoadingState();
     }
 
-    if (_loaderResult.state.error) {
+    if (_loaderResult.state.error && _loaderResult.state.data == null) {
       return _buildErrorState();
     }
 
@@ -422,89 +440,40 @@ class VerseCard extends StatelessWidget {
           SizedBox(height: 16),
 
           // Original line (blue)
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                margin: EdgeInsets.only(top: 12, right: 8),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF3B82F6),
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              Expanded(
-                child: Text(
-                  original,
-                  textDirection:
-                      rtl_original ? TextDirection.rtl : TextDirection.ltr,
-                  style: GoogleFonts.notoSerif(
-                    color: const Color(0xFF93C5FD),
-                    fontSize: 16,
-                    fontWeight: FontWeight.w400,
-                    height: 1.4,
-                  ),
-                ),
-              ),
-            ],
+          Text(
+            original,
+            textDirection: rtl_original ? TextDirection.rtl : TextDirection.ltr,
+            style: GoogleFonts.notoSerif(
+              color: const Color(0xFF93C5FD),
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+              height: 1.4,
+            ),
           ),
           SizedBox(height: 24),
 
           // Transliteration line (violet, italic)
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                margin: EdgeInsets.only(top: 12, right: 8),
-                decoration: BoxDecoration(
-                  color: const Color(0xFFA78BFA),
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              Expanded(
-                child: Text(
-                  translit,
-                  style: GoogleFonts.inter(
-                    color: Colors.white,
-                    fontSize: 14,
-                    fontStyle: FontStyle.italic,
-                    fontWeight: FontWeight.w400,
-                    height: 1.4,
-                  ),
-                ),
-              ),
-            ],
+          Text(
+            translit,
+            style: GoogleFonts.inter(
+              color: Colors.white,
+              fontSize: 14,
+              fontStyle: FontStyle.italic,
+              fontWeight: FontWeight.w400,
+              height: 1.4,
+            ),
           ),
           SizedBox(height: 24),
 
           // Portuguese line (amber)
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                margin: EdgeInsets.only(top: 12, right: 8),
-                decoration: BoxDecoration(
-                  color: const Color(0xFFFCD34D),
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              Expanded(
-                child: Text(
-                  pt,
-                  style: GoogleFonts.inter(
-                    color: const Color(0xFFFCD34D),
-                    fontSize: 14,
-                    fontWeight: FontWeight.w400,
-                    height: 1.4,
-                  ),
-                ),
-              ),
-            ],
+          Text(
+            pt,
+            style: GoogleFonts.inter(
+              color: const Color(0xFFFCD34D),
+              fontSize: 14,
+              fontWeight: FontWeight.w400,
+              height: 1.4,
+            ),
           ),
         ],
       ),
@@ -674,7 +643,8 @@ Future<String?> safeFetchMulti(String bookSlug, int chapter) async {
   return null;
 }
 
-ChapterLoaderResult useChapterLoader(String bookSlugParam, int chapterParam) {
+ChapterLoaderResult useChapterLoader(String bookSlugParam, int chapterParam,
+    {VoidCallback? onStateChange}) {
   final bookSlug = (bookSlugParam.isNotEmpty) ? bookSlugParam : "joao";
   final chapterNum = chapterParam > 0 ? chapterParam : 1;
 
@@ -685,6 +655,7 @@ ChapterLoaderResult useChapterLoader(String bookSlugParam, int chapterParam) {
       state.loading = false;
       state.error = false;
       state.data = MOCK_JOAO_1;
+      onStateChange?.call();
       return;
     }
 
@@ -707,6 +678,7 @@ ChapterLoaderResult useChapterLoader(String bookSlugParam, int chapterParam) {
       state.data = json;
       state.loading = false;
       state.error = false;
+      onStateChange?.call();
       return;
     }
 
@@ -714,12 +686,14 @@ ChapterLoaderResult useChapterLoader(String bookSlugParam, int chapterParam) {
       state.data = MOCK_JOAO_1;
       state.loading = false;
       state.error = false;
+      onStateChange?.call();
       return;
     }
 
     state.loading = false;
     state.error = true;
     state.data = null;
+    onStateChange?.call();
   }
 
   void retry() {


### PR DESCRIPTION
## Summary
- show verses without bullet markers
- load João 1 from local JSON with fallback and error handling
- update chapter loader to refresh widget state

## Testing
- `dart format lib/presentation/bible_text_reader/bible_text_reader.dart assets/bible/joao/1.json` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cede367308333a81f2f8bf9b5ea63