### PR TITLE
feat: add local chapter loader

### DIFF
--- a/lib/services/local_chapter_loader.dart
+++ b/lib/services/local_chapter_loader.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+Future<Map<String, dynamic>?> loadChapterJson(String slug, int chapter) async {
+  final candidates = [
+    'assets/bible/$slug/$chapter.json',
+    'assets/bible/$slug/$chapter.JSON',
+  ];
+  for (final path in candidates) {
+    try {
+      final s = await rootBundle.loadString(path);
+      final json = jsonDecode(s) as Map<String, dynamic>;
+      final verses = json['verses'];
+      if (verses is List && verses.isNotEmpty) return json;
+    } catch (_) {}
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add helper to load local bible chapter JSON assets

## Testing
- `dart format lib/services/local_chapter_loader.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce57af5dc8333ad2a970a5698f0e7